### PR TITLE
fix: completed label overlapping name (QA#4)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1801,7 +1801,7 @@ html {
 
 .card-stamp {
   position: absolute;
-  top: 16px;
+  bottom: 16px;
   right: 12px;
   transform: rotate(10deg);
   padding: 6px 32px;


### PR DESCRIPTION
**Issue:**
 -  前端 QA list #4
 
 **Problem:**
 - 物資媒合，已完成 component 蓋到 name
<img width="472" height="994" alt="Before" src="https://github.com/user-attachments/assets/522ee1d7-47ac-46a0-8e63-3b3bb84e42bc" />

**Reason:**
 - The CSS relative position from the top-right corner caused overlap; changed to bottom-right.

**Updated:**
 - Adjusted CSS relative positioning.
<img width="482" height="1006" alt="After" src="https://github.com/user-attachments/assets/42bebc18-9cf9-478e-b88c-bc57d731080a" />

**Simulate mobile devices with device mode | Chrome DevTools:** 
 - iPhone 14 Pro Max viewport
